### PR TITLE
Fix CI workflow for left-handed firmware builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Build firmware
-        uses: xanderhendriks/action-build-stm32cubeide@v12.0.0
+        uses: xanderhendriks/action-build-stm32cubeide@v16.1
         with:
           project-path: '/github/workspace/mouse'
           project-target: 'all'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,20 +3,24 @@ on:
   push:
     branches:
       - main
+      - 'claude/**'
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build firmware
-        uses: xanderhendriks/action-build-stm32cubeide@master
+        uses: xanderhendriks/action-build-stm32cubeide@v12.0.0
         with:
           project-path: '/github/workspace/mouse'
           project-target: 'all'
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: m2k_fw_lh
           path: mouse/Release/mouse.bin


### PR DESCRIPTION
- Add trigger for claude/** branches so CI runs on feature branches
- Add pull_request trigger for main branch
- Update actions/checkout from v3 to v4 (v3 deprecated)
- Update actions/upload-artifact from v3 to v4 (v3 deprecated)
- Pin xanderhendriks/action-build-stm32cubeide to v12.0.0 for stability

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update CI workflow to run on feature branches and PRs to main, and bump action versions (checkout v4, STM32CubeIDE builder v16.1, upload-artifact v4).
> 
> - **CI Workflow (`.github/workflows/ci.yaml`)**:
>   - **Triggers**: Add `push` on `claude/**` and `pull_request` for `main`.
>   - **Actions**: Upgrade `actions/checkout` to `v4`, `xanderhendriks/action-build-stm32cubeide` to `v16.1`, and `actions/upload-artifact` to `v4`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f25d1249cd98aec04e705406eb54c5ad4d52756. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->